### PR TITLE
Create intermediate groups during dataset creation

### DIFF
--- a/h5read.cc
+++ b/h5read.cc
@@ -414,7 +414,8 @@ DEFUN_DLD (h5create, args, nargout,
 @deftypefn {Loadable Function} h5create (@var{filename}, @var{dsetname}, @var{size}, @var{key}, @var{val},...)\n\
 \n\
 Create a dataset with name @var{dsetname} and size @var{size} \n\
-in the HDF5 file specified by @var{filename}.\n\
+in the HDF5 file specified by @var{filename}.  Intermediate groups\n\
+are created as necessary.\n\
 \n\
 The vector @var{size} may contain one or several Inf (or \n\
 equivalently: zero) values.\n\
@@ -1555,15 +1556,19 @@ H5File::create_dset (const char *location, const Matrix& size,
         }
       free (dims_chunk);
     }
-  
+
+  // create non-existent intermediate groups.
+  hid_t lcpl_list = H5Pcreate (H5P_LINK_CREATE);
+  H5Pset_create_intermediate_group (lcpl_list, 1);
   dset_id = H5Dcreate (file, location, type_id, dspace_id,
-                       H5P_DEFAULT, crp_list, H5P_DEFAULT);
+                       lcpl_list, crp_list, H5P_DEFAULT);
   if (dset_id < 0)
     {
       error ("Could not create dataset %s", location);
       return;
     }
   H5Pclose (crp_list);
+  H5Pclose (lcpl_list);
 
 }
 

--- a/test/h5test.m
+++ b/test/h5test.m
@@ -110,6 +110,9 @@ read_write_chunk_at("test.h5","created_dset_inf2",datachunk,start)
 %%%%%%%%
 h5create("test.h5","created_dset_inf23",[ 2 3 4],'Datatype','int8', 'ChunkSize', [2 3 2])
 
+%%%%%%%%
+h5create("test.h5","/nonexistent/groups/created_dset_single",[1],'Datatype','single')
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 disp("Test h5write and h5read...")
 


### PR DESCRIPTION
Added support for creating intermediate groups when using h5create().  Previously one could not create non-floating point data sets that did not reside in the root group (/) as h5write() (withintermediate group creation) only handles floating point.  Updated the test suite to include a new test for h5create().