### PR TITLE
removed deprecated gripes.h, replaced with errwarn.h

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ integer and string.
 To install, just use
 
     make
-    
+
 This will produce a package file named "hdf5oct-*.tar.gz" .  Then
 you may either install the package with
 
@@ -48,7 +48,7 @@ you may either install the package with
 or you may start GNU Octave and install the package manually (using
 the correct file name) with the command
 
-    pkg install hdf5oct-0.2.0.tar.gz
+    pkg install hdf5oct-0.4.0.tar.gz
 
 This will put the *.oct files somewhere where Octave will find them.
 You can try running

--- a/h5read.cc
+++ b/h5read.cc
@@ -61,7 +61,7 @@ using namespace std;
 bool
 any_int_leq_zero (const Matrix& mat)
 {
-  for (int i = 0; i < mat.numel (); i++)
+  for (int i = 0; i < mat.length (); i++)
     {
       if (mat(i) < 0.5)
         return true;
@@ -88,7 +88,7 @@ check_vec (const octave_value& val, Matrix& mat/*out*/,
   double mind, maxd;
   if (allow_zeros)
     {
-      for (int i = 0; i < mat.numel (); i++)
+      for (int i = 0; i < mat.length (); i++)
         {
           if (mat(i) == octave_Inf)
             mat(i) = 0;
@@ -154,7 +154,7 @@ the appropriate size for the given HDF5 type.\n\
   warn_disabled_feature ("h5read", "HDF5 IO");
   return octave_value ();
 #else
-  int nargin = args.numel ();
+  int nargin = args.length ();
 
   if (nargin < 2 || nargin == 3 || nargin > 6 || nargout > 1)
     {
@@ -228,7 +228,7 @@ is to read.\n\
   warn_disabled_feature ("h5readatt", "HDF5 IO");
   return octave_value ();
 #else
-  int nargin = args.numel ();
+  int nargin = args.length ();
   if (nargin != 3)
     {
       print_usage ();
@@ -299,7 +299,7 @@ the appropriate size for the given Octave type.\n\
   warn_disabled_feature ("h5write", "HDF5 IO");
   return octave_value ();
 #else
-  int nargin = args.numel ();
+  int nargin = args.length ();
 
   if (! (nargin == 3 || nargin == 5 || nargin  == 6 || nargin == 7) || nargout != 0)
     {
@@ -379,7 +379,7 @@ the object named @var{objectname} in the HDF5 file specified by @var{filename}.\
   warn_disabled_feature ("h5writeatt", "HDF5 IO");
   return octave_value ();
 #else
-  int nargin = args.numel ();
+  int nargin = args.length ();
 
   if (nargin != 4 || nargout != 0)
     {
@@ -448,7 +448,7 @@ setting is not @sc{matlab} compatible.\n\
   warn_disabled_feature("h5create", "HDF5 IO");
   return octave_value ();
 #else
-  int nargin = args.numel ();
+  int nargin = args.length ();
 
   if (! (nargin ==  3 || nargin == 5 || nargin == 7) || nargout != 0)
     {
@@ -547,7 +547,7 @@ Note that this function is not @sc{matlab} compliant.\n\
   warn_disabled_feature("h5delete", "HDF5 IO");
   return octave_value ();
 #else
-  int nargin = args.numel ();
+  int nargin = args.length ();
 
   if (! (nargin ==  2 || nargin == 3) || nargout != 0)
     {
@@ -662,7 +662,7 @@ template <typename T>
 hsize_t*
 H5File::alloc_hsize (const T& dim, const int mode, const bool reverse)
 {
-  int rank = dim.numel ();
+  int rank = dim.length ();
   hsize_t *hsize = (hsize_t*)malloc (rank * sizeof (hsize_t));
   for (int i = 0; i < rank; i++)
     {
@@ -725,7 +725,7 @@ H5File::read_dset_complete (const char *dsetname)
     return octave_value ();
 
   mat_dims.resize (max (rank, 2));
-  // .resize(1) still leaves mat_dims with a numel of 2 for some reason, so
+  // .resize(1) still leaves mat_dims with a length of 2 for some reason, so
   // we need at least 2 filled
   mat_dims(0) = mat_dims(1) = 1;
   for (int i = 0; i < rank; i++)
@@ -758,35 +758,35 @@ H5File::read_dset_hyperslab (const char *dsetname,
       return octave_value ();
     }
 
-  if (start.numel () != rank)
+  if (start.length () != rank)
     {
-      error ("start must be a vector of numel %d, the dataset rank", rank);
+      error ("start must be a vector of length %d, the dataset rank", rank);
       return octave_value ();
     }
-  if (count.numel () != rank)
+  if (count.length () != rank)
     {
-      error ("count must be a vector of numel %d, the dataset rank", rank);
+      error ("count must be a vector of length %d, the dataset rank", rank);
       return octave_value ();
     }
 
   Matrix _stride = stride;
   if (nargin < 3)
     _stride = Matrix (dim_vector(1, rank), 1);
-  if (_stride.numel () != rank)
+  if (_stride.length () != rank)
     {
-      error ("stride must be a vector of numel %d, the dataset rank", rank);
+      error ("stride must be a vector of length %d, the dataset rank", rank);
       return octave_value ();
     }
   Matrix _block = block;
   if (nargin < 4)
     _block = Matrix (dim_vector(1, rank), 1);
-  if (_block.numel () != rank)
+  if (_block.length () != rank)
     {
-      error ("block must be a vector of numel %d, the dataset rank", rank);
+      error ("block must be a vector of length %d, the dataset rank", rank);
       return octave_value ();
     }
 
-  // .resize(1) still leaves mat_dims with a numel of 2 for some reason, so
+  // .resize(1) still leaves mat_dims with a length of 2 for some reason, so
   // we need at least 2 filled
   mat_dims.resize (max (rank, 2));
   mat_dims(0) = mat_dims(1) = 1;
@@ -863,17 +863,17 @@ H5File::read_dset ()
           return octave_value ();                                  \
         }                                                               \
                                                                         \
-      int mdc_numel = -1;                                               \
-      size_t rdcc_numel = -1;                                           \
+      int mdc_length = -1;                                               \
+      size_t rdcc_length = -1;                                           \
       size_t rdcc_nbytes = -1;                                          \
       double rdcc_w0 = -1;                                              \
-      if (H5Pget_cache (H5Fget_access_plist (file), &mdc_numel,         \
-                        &rdcc_numel, &rdcc_nbytes, &rdcc_w0 ) < 0)      \
+      if (H5Pget_cache (H5Fget_access_plist (file), &mdc_length,         \
+                        &rdcc_length, &rdcc_nbytes, &rdcc_w0 ) < 0)      \
         {                                                               \
           error ("could not determine raw data chunk cache parameters."); \
           return octave_value ();                                  \
         }                                                               \
-      /*cout << "cache params:" << rdcc_numel << "," << rdcc_nbytes << endl;*/ \
+      /*cout << "cache params:" << rdcc_length << "," << rdcc_nbytes << endl;*/ \
       herr_t read_result = H5Dread (dset_id,                            \
                                     type,                               \
                                     H5S_ALL, dspace_id,                 \
@@ -970,7 +970,7 @@ void
 H5File::write_dset (const char *dsetname,
                     const octave_value ov_data)
 {
-  int rank = ov_data.dims ().numel ();
+  int rank = ov_data.dims ().length ();
 
   hsize_t *dims = alloc_hsize (ov_data.dims(), ALLOC_HSIZE_DEFAULT, true);
   dspace_id = H5Screate_simple (rank, dims, NULL);
@@ -986,7 +986,7 @@ H5File::write_dset (const char *dsetname,
 
   //check if all groups in the path dsetname exist. if not, create them
   string path (dsetname);
-  for (int i=1; i < path.numel (); i++)
+  for (int i=1; i < path.length (); i++)
     {
       if (path[i] == '/')
         {
@@ -1125,30 +1125,30 @@ H5File::write_dset_hyperslab (const char *dsetname,
       return;
     }
 
-  if (start.numel () != rank)
+  if (start.length () != rank)
     {
-      error ("start must be a vector of numel %d, the dataset rank", rank);
+      error ("start must be a vector of length %d, the dataset rank", rank);
       return;
     }
-  if (count.numel () != rank)
+  if (count.length () != rank)
     {
-      error ("count must be a vector of numel %d, the dataset rank", rank);
+      error ("count must be a vector of length %d, the dataset rank", rank);
       return;
     }
   Matrix _stride = stride;
   if (nargin < 3)
     _stride = Matrix (dim_vector(1, rank), 1);
-  if (_stride.numel () != rank)
+  if (_stride.length () != rank)
     {
-      error ("stride must be a vector of numel %d, the dataset rank", rank);
+      error ("stride must be a vector of length %d, the dataset rank", rank);
       return;
     }
   Matrix _block = block;
   if (nargin < 4)
     _block = Matrix (dim_vector(1, rank), 1);
-  if (_block.numel () != rank)
+  if (_block.length () != rank)
     {
-      error ("block must be a vector of numel %d, the dataset rank", rank);
+      error ("block must be a vector of length %d, the dataset rank", rank);
       return;
     }
 
@@ -1410,7 +1410,7 @@ H5File::write_att (const char *location, const char *attname,
   if (attvalue.is_string ())
     {
       type_id = H5Tcopy (H5T_C_S1);
-      H5Tset_size (type_id, attvalue.string_value ().numel ());
+      H5Tset_size (type_id, attvalue.string_value ().length ());
       H5Tset_strpad (type_id,H5T_STR_NULLTERM);
       mem_type_id = H5Tcopy (type_id);
 
@@ -1524,7 +1524,7 @@ H5File::create_dset (const char *location, const Matrix& size,
   hsize_t *dims = alloc_hsize (size, ALLOC_HSIZE_INF_TO_ZERO, true);
   // and produce unlimited maximum extent for..
   hsize_t *maxdims = alloc_hsize (size, ALLOC_HSIZE_INFZERO_TO_UNLIMITED, true);
-  dspace_id = H5Screate_simple (size.numel (), dims, maxdims);
+  dspace_id = H5Screate_simple (size.length (), dims, maxdims);
   free (dims);
   free (maxdims);
 
@@ -1547,7 +1547,7 @@ H5File::create_dset (const char *location, const Matrix& size,
           error ("Could not set chunked layout of %s", location);
           return;
         }
-      if (H5Pset_chunk (crp_list, size.numel (), dims_chunk) < 0)
+      if (H5Pset_chunk (crp_list, size.length (), dims_chunk) < 0)
         {
           error ("Could not set chunk size of %s", location);
           return;
@@ -1604,7 +1604,7 @@ H5File::get_auto_chunksize(const Matrix& dset_shape, int typesize)
   const int CHUNK_MAX = 1024*1024; // Hard upper limit (1M)
 
   Matrix chunksize = dset_shape;
-  int ndims = chunksize.numel ();
+  int ndims = chunksize.length ();
   for (int i = 0; i < ndims; i++)
     {
       //For unlimited dimensions we have to guess 1024

--- a/h5read.cc
+++ b/h5read.cc
@@ -38,7 +38,7 @@
 #include <iostream>
 #include <algorithm>
 #include <string>
-#include "gripes.h"
+#include "errwarn.h"
 #include "file-stat.h"
 
 using namespace std;
@@ -100,7 +100,7 @@ check_vec (const octave_value& val, Matrix& mat/*out*/,
     {
       error ("%s can only contain positive integers", name);
       return 0;
-    } 
+    }
 
   return 1;
 }
@@ -148,7 +148,7 @@ the appropriate size for the given HDF5 type.\n\
 @end deftypefn")
 {
 #if ! (defined (HAVE_HDF5) && defined (HAVE_HDF5_18))
-  gripe_disabled_feature ("h5read", "HDF5 IO");
+  warn_disabled_feature ("h5read", "HDF5 IO");
   return octave_value_list ();
 #else
   int nargin = args.length ();
@@ -183,7 +183,7 @@ the appropriate size for the given HDF5 type.\n\
     {
       Matrix start, count, stride, block;
       int err = 0;
-    
+
       err = err || ! check_vec (args(2), start, "START", false);
       start -= 1;
 
@@ -222,7 +222,7 @@ is to read.\n\
 {
   octave_value retval;
 #if ! (defined (HAVE_HDF5) && defined (HAVE_HDF5_18))
-  gripe_disabled_feature ("h5readatt", "HDF5 IO");
+  warn_disabled_feature ("h5readatt", "HDF5 IO");
   return octave_value_list ();
 #else
   int nargin = args.length ();
@@ -242,12 +242,12 @@ is to read.\n\
   string attname = args(2).string_value ();
   if (error_state)
     return octave_value_list ();
-  
+
   //open the hdf5 file
   H5File file (filename.c_str (), false);
   if (error_state)
     return octave_value_list ();
-        
+
   retval = file.read_att (objname.c_str (), attname.c_str ());
   return retval;
 
@@ -293,7 +293,7 @@ the appropriate size for the given Octave type.\n\
 @end deftypefn")
 {
 #if ! (defined (HAVE_HDF5) && defined (HAVE_HDF5_18))
-  gripe_disabled_feature ("h5write", "HDF5 IO");
+  warn_disabled_feature ("h5write", "HDF5 IO");
   return octave_value_list ();
 #else
   int nargin = args.length ();
@@ -310,10 +310,10 @@ the appropriate size for the given Octave type.\n\
     }
   string filename = args(0).string_value ();
   string location = args(1).string_value ();
-  
+
   if (error_state)
     return octave_value_list ();
-    
+
 
   if (nargin == 3)
     {
@@ -324,7 +324,7 @@ the appropriate size for the given Octave type.\n\
       file.write_dset (location.c_str (),
                        args(2));
     }
-  else  
+  else
     {
       //open the hdf5 file, complain if it does not exist
       H5File file (filename.c_str (), false);
@@ -373,7 +373,7 @@ the object named @var{objectname} in the HDF5 file specified by @var{filename}.\
 @end deftypefn")
 {
 #if ! (defined (HAVE_HDF5) && defined (HAVE_HDF5_18))
-  gripe_disabled_feature ("h5writeatt", "HDF5 IO");
+  warn_disabled_feature ("h5writeatt", "HDF5 IO");
   return octave_value_list ();
 #else
   int nargin = args.length ();
@@ -392,10 +392,10 @@ the object named @var{objectname} in the HDF5 file specified by @var{filename}.\
   string filename = args(0).string_value ();
   string location = args(1).string_value ();
   string attname = args(2).string_value ();
-  
+
   if (error_state)
     return octave_value_list ();
-    
+
   //open the hdf5 file
   H5File file (filename.c_str (), false);
   if (error_state)
@@ -442,7 +442,7 @@ setting is not @sc{matlab} compatible.\n\
 @end deftypefn")
 {
 #if ! (defined (HAVE_HDF5) && defined (HAVE_HDF5_18))
-  gripe_disabled_feature("h5create", "HDF5 IO");
+  warn_disabled_feature("h5create", "HDF5 IO");
   return octave_value_list ();
 #else
   int nargin = args.length ();
@@ -467,7 +467,7 @@ setting is not @sc{matlab} compatible.\n\
   string location = args(1).string_value ();
   if (error_state)
     return octave_value_list ();
-  
+
   Matrix size;
   if (! check_vec (args(2), size, "SIZE", true))
     return octave_value_list ();
@@ -510,14 +510,14 @@ setting is not @sc{matlab} compatible.\n\
         }
     }
 
-  
-  
+
+
   //open the hdf5 file
   H5File file (filename.c_str (), true);
   if (error_state)
     return octave_value_list ();
   file.create_dset (location.c_str (), size, datatype.c_str (), chunksize);
-  
+
   return octave_value_list ();
 #endif
 }
@@ -541,7 +541,7 @@ Note that this function is not @sc{matlab} compliant.\n\
 @end deftypefn")
 {
 #if ! (defined (HAVE_HDF5) && defined (HAVE_HDF5_18))
-  gripe_disabled_feature("h5delete", "HDF5 IO");
+  warn_disabled_feature("h5delete", "HDF5 IO");
   return octave_value_list ();
 #else
   int nargin = args.length ();
@@ -561,7 +561,7 @@ Note that this function is not @sc{matlab} compliant.\n\
       print_usage ();
       return octave_value_list ();
     }
-  
+
   string filename = args(0).string_value ();
   string location = args(1).string_value ();
   if (error_state)
@@ -579,7 +579,7 @@ Note that this function is not @sc{matlab} compliant.\n\
       if(!error_state)
 	file.delete_att (location.c_str (), attname.c_str ());
     }
-  
+
   return octave_value_list ();
 #endif
 }
@@ -625,7 +625,7 @@ H5File::~H5File ()
 
   if (H5Iis_valid (dset_id))
     H5Dclose (dset_id);
-  
+
   if (H5Iis_valid (att_id))
     H5Aclose (att_id);
 
@@ -634,7 +634,7 @@ H5File::~H5File ()
 
   if (H5Iis_valid (type_id))
     H5Tclose (type_id);
-  
+
   if (H5Iis_valid (mem_type_id))
     H5Tclose (mem_type_id);
 
@@ -711,7 +711,7 @@ H5File::open_dset (const char *dsetname)
       error ("Error determining current dimensions and maximum size of dataset %s", dsetname);
       return -1;
     }
-  
+
   return 0;
 }
 
@@ -765,7 +765,7 @@ H5File::read_dset_hyperslab (const char *dsetname,
       error ("count must be a vector of length %d, the dataset rank", rank);
       return octave_value_list ();
     }
-  
+
   Matrix _stride = stride;
   if (nargin < 3)
     _stride = Matrix (dim_vector(1, rank), 1);
@@ -782,7 +782,7 @@ H5File::read_dset_hyperslab (const char *dsetname,
       error ("block must be a vector of length %d, the dataset rank", rank);
       return octave_value_list ();
     }
-  
+
   // .resize(1) still leaves mat_dims with a length of 2 for some reason, so
   // we need at least 2 filled
   mat_dims.resize (max (rank, 2));
@@ -882,7 +882,7 @@ H5File::read_dset ()
         }                                                               \
       retval = octave_value (ret)
       // macro end
-      
+
       HDF5_READ_DATA (type_id);
     }
   else if (H5Tget_class (type_id) == H5T_INTEGER)
@@ -959,7 +959,7 @@ H5File::read_dset ()
       HDF5_READ_DATA (H5T_NATIVE_DOUBLE);
     }
   H5Tclose (complex_type_id);
-  
+
   return retval;
 }
 
@@ -1002,7 +1002,7 @@ H5File::write_dset (const char *dsetname,
       //check if the data set already exists. if it does, open it,
       //otherwise, create it.  Furthermore check if the datatype is
       //compliant with given octave data.
-  
+
 #define OPEN_AND_WRITE if (H5Lexists (file,dsetname,H5P_DEFAULT))       \
         {                                                               \
           if (open_dset (dsetname) < 0)                                 \
@@ -1018,7 +1018,7 @@ H5File::write_dset (const char *dsetname,
       status = H5Dwrite (dset_id, type_id,                              \
                          H5S_ALL, H5S_ALL, H5P_DEFAULT,                 \
                          data.fortran_vec ())
-  
+
       type_id = hdf5_make_complex_type (H5T_NATIVE_DOUBLE);
       ComplexNDArray data = ov_data.complex_array_value ();
       OPEN_AND_WRITE;
@@ -1079,7 +1079,7 @@ H5File::write_dset (const char *dsetname,
           type_id = H5Tcopy (H5T_NATIVE_INT);
           OPEN_AND_WRITE;
         }
-      
+
     }
   else if (ov_data.is_single_type ())
     {
@@ -1182,7 +1182,7 @@ H5File::write_dset_hyperslab (const char *dsetname,
   hsize_t *hcount = alloc_hsize (count, ALLOC_HSIZE_DEFAULT, true);
   hsize_t *hblock = alloc_hsize (_block, ALLOC_HSIZE_DEFAULT, true);
   // TODO check these (and hmem) for NULLs
-  
+
   // make the current size of the dataset bigger
   H5Sclose (dspace_id);
   if (H5Dset_extent (dset_id, h5_dims) < 0)
@@ -1209,7 +1209,7 @@ H5File::write_dset_hyperslab (const char *dsetname,
       error ("error when selecting the hyperslab of dataset %s to write to", dsetname);
       return;
     }
-  
+
   hsize_t *hmem = alloc_hsize (data.dims (), ALLOC_HSIZE_DEFAULT, false);
   hid_t memspace_id = H5Screate_simple (rank, hmem, hmem);
   if (memspace_id < 0)
@@ -1218,7 +1218,7 @@ H5File::write_dset_hyperslab (const char *dsetname,
       return;
     }
   free (hmem);
-  
+
   herr_t status = H5Dwrite (dset_id, H5T_NATIVE_DOUBLE,
                             memspace_id, dspace_id, H5P_DEFAULT,
                             data.fortran_vec ());
@@ -1227,7 +1227,7 @@ H5File::write_dset_hyperslab (const char *dsetname,
       error ("error when writing the dataset %s", dsetname);
       return;
     }
-  
+
 }
 
 
@@ -1268,7 +1268,7 @@ H5File::read_att (const char *objname, const char *attname)
     {
       // Size of each string:
       size_t size = H5Tget_size (type);
-      // to read an array of strings (for future work): 
+      // to read an array of strings (for future work):
       //totsize = size*sdim[0]*sdim[1];
       // to read a single string:
       size_t totsize = size;
@@ -1284,7 +1284,7 @@ H5File::read_att (const char *objname, const char *attname)
   else if (H5Tget_class (type)==H5T_INTEGER)
     {
       // Integer attributes are casted to floating point octave values
-    
+
       double value[numVal];
       if (H5Tget_size (type)==sizeof (int))
         {
@@ -1307,7 +1307,7 @@ H5File::read_att (const char *objname, const char *attname)
       for (size_t n=0;n<numVal;++n)
         mat(n)=value[n];
       retval = octave_value (mat);
-    
+
     }
   else if (H5Tget_class (type) == H5T_FLOAT)
     {
@@ -1349,7 +1349,7 @@ cannot handle size of type");
       error ("h5readatt: attribute type not supported");
       return retval;
     }
-  
+
   return retval;
 }
 
@@ -1386,7 +1386,7 @@ H5File::write_att (const char *location, const char *attname,
       error ("the specified HDF5 object %s could not be opened", location);
       return;
     }
-  
+
   //Check if an attribute with the given name exists already at that
   //object and if yes delete it.
   htri_t exists = H5Aexists (obj_id, attname);
@@ -1414,7 +1414,7 @@ H5File::write_att (const char *location, const char *attname,
       H5Tset_size (type_id, attvalue.string_value ().length ());
       H5Tset_strpad (type_id,H5T_STR_NULLTERM);
       mem_type_id = H5Tcopy (type_id);
-      
+
       buf = (void *) attvalue.string_value ().c_str ();
     }
   else if (attvalue.is_integer_type ())
@@ -1541,7 +1541,7 @@ H5File::create_dset (const char *location, const Matrix& size,
       // a dataset with an unlimited dimension must be chunked.
       if (chunksize(0) == 0)
 	chunksize = get_auto_chunksize(size, typesize);
-      
+
       hsize_t *dims_chunk = alloc_hsize (chunksize, ALLOC_HSIZE_DEFAULT, true);
       if (H5Pset_layout (crp_list, H5D_CHUNKED) < 0)
         {
@@ -1555,7 +1555,7 @@ H5File::create_dset (const char *location, const Matrix& size,
         }
       free (dims_chunk);
     }
-  
+
   dset_id = H5Dcreate (file, location, type_id, dspace_id,
                        H5P_DEFAULT, crp_list, H5P_DEFAULT);
   if (dset_id < 0)
@@ -1595,7 +1595,7 @@ Matrix
 H5File::get_auto_chunksize(const Matrix& dset_shape, int typesize)
 {
   // This function originally stems from the h5py project.
-  
+
   // Guess an appropriate chunk layout for a dataset, given its shape and
   // the size of each element in bytes. Will allocate chunks only as large
   // as MAX_SIZE. Chunks are generally close to some power-of-2 fraction of
@@ -1634,10 +1634,10 @@ H5File::get_auto_chunksize(const Matrix& dset_shape, int typesize)
 	   abs(chunk_bytes-target_size)/target_size < 0.5) &&
 	  chunk_bytes < CHUNK_MAX)
 	break;
-      
+
       if (chunksize.prod ()(0) == 1)
 	break; // Element size larger than CHUNK_MAX
-      
+
       chunksize(idx%ndims) = ceil(chunksize(idx%ndims) / 2.0);
       idx++;
     }

--- a/package/DESCRIPTION
+++ b/package/DESCRIPTION
@@ -1,5 +1,5 @@
 Name: hdf5oct
-Version: 0.2.0
+Version: 0.4.0
 Date: 2015-10-02
 Author: Tom Mullins, Anton Starikov, Thorsten Liebig, Stefan Großhauser
 Maintainer: Stefan Großhauser <Stefan.Grosshauser@uni-bayreuth.de>


### PR DESCRIPTION
gripes.* is deprecated in newer versions of Octave. It was replaced by errwarn.*. The necessary changes have been made below. Let me know what you think!